### PR TITLE
Provide tool to zip cookiecutters for use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+publish/
+.DS_Store

--- a/cookiecutters/demo/cookiecutter.json
+++ b/cookiecutters/demo/cookiecutter.json
@@ -1,0 +1,5 @@
+{
+  "project_name": "Demo",
+  "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '_') }}",
+  "author": "Anonymous"
+}

--- a/cookiecutters/demo/{{ cookiecutter.project_slug }}/index.html
+++ b/cookiecutters/demo/{{ cookiecutter.project_slug }}/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>{{ cookiecutter.project_name }}</title>
+  </head>
+
+  <body>
+    <h1>{{ cookiecutter.project_name }}</h1>
+    <p>by {{ cookiecutter.author }}</p>
+  </body>
+</html>

--- a/tools/publish.sh
+++ b/tools/publish.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# NOTE: Tool to zip a given cookiecutter and drop off
+# in the directory 'publish' in the root of the repo
+
+RESET_COLOR='\033[0m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+
+# Ensure execution context is in project directory
+cd $(dirname $0)
+
+ROOT_DIR=$(git rev-parse --show-toplevel)
+PUBLISH_DIR="$ROOT_DIR/publish"
+COOKIECUTTER_DIR="$ROOT_DIR/cookiecutters"
+
+# Prompt for cookiecutter to zip for publish
+TARGET_COOKIECUTTER=$(ls $COOKIECUTTER_DIR | fzf --prompt="Select a cookiecutter to publish ❯ ")
+ZIP="$TARGET_COOKIECUTTER.zip"
+
+# Zip cookiecutter and drop off in /publish dir in root of repo
+cd $COOKIECUTTER_DIR
+zip -r --quiet $ZIP $TARGET_COOKIECUTTER
+mkdir -p "$PUBLISH_DIR"
+mv $ZIP "$PUBLISH_DIR/$ZIP"
+
+echo -e "${GREEN}[PUBLISHED]${RESET_COLOR} Cookiecutter ${YELLOW}$TARGET_COOKIECUTTER${RESET_COLOR} to ${YELLOW}$PUBLISH_DIR/$ZIP${RESET_COLOR}"


### PR DESCRIPTION
This PR introduces a new tool `publish.sh` which zips and publishes a selected cookiecutter to a `publish` directory in the root of the repository.

A cookiecutter named `demo` has been created to showcase this, and also serve as a general example. It was created following [the cookiecutter official docs](https://cookiecutter.readthedocs.io/en/latest/tutorials/tutorial2.html).