### PR TITLE
terraform-azure - support config and shared modules, trivy and tflint config, and bug fix

### DIFF
--- a/cookiecutters/terraform-azure/README.md
+++ b/cookiecutters/terraform-azure/README.md
@@ -4,21 +4,23 @@ This cookiecutter provisions a module project defaulting to the Azure provider.
 
 ## Requirements
 
-- OpenTofu or Terraform
-- pre-commit
-- tflint
-- trivy
+- [OpenTofu](https://opentofu.org/) or [Terraform](https://developer.hashicorp.com/terraform)
+- [pre-commit](https://pre-commit.com/)
+- [tflint](https://github.com/terraform-linters/tflint)
+- [trivy](https://trivy.dev/latest/)
 
 ## Inputs
 
-- `create_git_repo` - Determines if a git repo will be created.
-- `use_git_hooks` - Determines if hooks using the pre-commit framework will be installed.
-- `author` - The module author.
-- `project_name` - The module name.
-- `project_slug` - Auto generated using `project_name`. The default should be accepted.
-- `short_project_description` - Inserted in the generated README header via terraform-docs.
+- `is_config_or_module` - Will omit the providers.tf file if use case is a
+    shared module (not config).
 - `use_opentofu` - If the project should be initalized using OpenTofu.
 - `terraform_or_tofu_version` - Sets the required version in the config.
 - `azure_provider_version` - Sets the required version in the config.
-- `azure_subscription_id` - Inserted into the provider config in tests/terraform.tftest.hcl
 - `azure_region` - Inserted into the sample test in tests/terraform.tftest.hcl
+- `project_name` - The module name.
+- `project_slug` - Auto generated using `project_name`. The default should be accepted.
+- `short_project_description` - Inserted in the generated README header via terraform-docs.
+- `author` - The module author.
+- `create_git_repo` - Determines if a git repo will be created.
+- `use_git_hooks` - Determines if hooks using the pre-commit framework will be installed.
+- `tests_azure_subscription_id` - Inserted into the provider config in tests/terraform.tftest.hcl

--- a/cookiecutters/terraform-azure/cookiecutter.json
+++ b/cookiecutters/terraform-azure/cookiecutter.json
@@ -9,7 +9,7 @@
   "use_opentofu": ["yes", "no"],
   "terraform_or_tofu_version": ">= 1.10.2",
   "azure_provider_version": ">= 4.35.0",
-  "azure_subscription_id": "",
   "azure_region": "eastus2",
+  "tests_azure_subscription_id": "",
   "_copy_without_render": ["*.terraform-docs.yml"]
 }

--- a/cookiecutters/terraform-azure/cookiecutter.json
+++ b/cookiecutters/terraform-azure/cookiecutter.json
@@ -1,15 +1,15 @@
 {
-  "create_git_repo": ["yes", "no"],
-  "use_git_hooks": ["yes", "no"],
-  "author": "Anonymous",
-  "project_name": "Example Module",
-  "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '_') }}",
-  "short_project_description": "",
   "is_config_or_module": ["config", "module"],
   "use_opentofu": ["yes", "no"],
   "terraform_or_tofu_version": ">= 1.10.2",
   "azure_provider_version": ">= 4.35.0",
   "azure_region": "eastus2",
+  "project_name": "Example Module",
+  "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '_') }}",
+  "short_project_description": "",
+  "author": "Anonymous",
+  "create_git_repo": ["yes", "no"],
+  "use_git_hooks": ["yes", "no"],
   "tests_azure_subscription_id": "",
   "_copy_without_render": ["*.terraform-docs.yml"]
 }

--- a/cookiecutters/terraform-azure/cookiecutter.json
+++ b/cookiecutters/terraform-azure/cookiecutter.json
@@ -5,6 +5,7 @@
   "project_name": "Example Module",
   "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '_') }}",
   "short_project_description": "",
+  "is_config_or_module": ["config", "module"],
   "use_opentofu": ["yes", "no"],
   "terraform_or_tofu_version": ">= 1.10.2",
   "azure_provider_version": ">= 4.35.0",

--- a/cookiecutters/terraform-azure/{{ cookiecutter.project_slug }}/.pre-commit-config.yaml
+++ b/cookiecutters/terraform-azure/{{ cookiecutter.project_slug }}/.pre-commit-config.yaml
@@ -2,8 +2,18 @@ repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.99.5 # Get the latest from: https://github.com/antonbabenko/pre-commit-terraform/releases
     hooks:
-      - id: terraform_fmt
-      - id: terraform_docs
-      - id: terraform_validate
-      - id: terraform_tflint
-      - id: terraform_trivy
+      - id: terraform_fmt{% if cookiecutter.use_opentofu == "yes" %}
+        args:
+          - --hook-config=--tf-path=tofu{% endif %}
+      - id: terraform_docs{% if cookiecutter.use_opentofu == "yes" %}
+        args:
+          - --hook-config=--tf-path=tofu{% endif %}
+      - id: terraform_validate{% if cookiecutter.use_opentofu == "yes" %}
+        args:
+          - --hook-config=--tf-path=tofu{% endif %}
+      - id: terraform_tflint{% if cookiecutter.use_opentofu == "yes" %}
+        args:
+          - --hook-config=--tf-path=tofu{% endif %}
+      - id: terraform_trivy{% if cookiecutter.use_opentofu == "yes" %}
+        args:
+          - --hook-config=--tf-path=tofu{% endif %}

--- a/cookiecutters/terraform-azure/{{ cookiecutter.project_slug }}/.tflint.hcl
+++ b/cookiecutters/terraform-azure/{{ cookiecutter.project_slug }}/.tflint.hcl
@@ -1,0 +1,35 @@
+tflint {
+  required_version = ">= 0.58.1"
+}
+
+config {
+  # stdout format
+  format = "default"
+
+  # where plugins, such as azurerm below, are installed
+  plugin_dir = "~/.tflint.d/plugins"
+
+  # lint the root module, no remote module sources
+  call_module_type = "local"
+
+  # change exit code on lint failure
+  force = false
+
+  # are plugin default enabled rules, enabled
+  disabled_by_default = false
+
+  # NOTE: Optional - set to n-number of var files as needed for better linting
+  # varfile = ["terraform.tfvars"]
+}
+
+plugin "azurerm" {
+  enabled = true
+  version = "0.28.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-azurerm"
+}
+
+# NOTE: This is the only rule not enabled by default from the azurerm rulset
+rule "azurerm_resource_missing_tags" {
+  enabled = true
+  tags    = ["owner", "purpose"]
+}

--- a/cookiecutters/terraform-azure/{{ cookiecutter.project_slug }}/main.tf
+++ b/cookiecutters/terraform-azure/{{ cookiecutter.project_slug }}/main.tf
@@ -1,3 +1,10 @@
+locals {
+  tags = merge(var.tags, {
+    owner   = "josh@joshlawrence.dev",
+    purpose = "Generated module via https://github.com/joshslawrence/cookiecutter"
+  })
+}
+
 module "naming" {
   source  = "Azure/naming/azurerm"
   version = "0.4.2"
@@ -7,5 +14,5 @@ module "naming" {
 resource "azurerm_resource_group" "this" {
   name     = module.naming.resource_group.name
   location = var.location
-  tags     = var.tags
+  tags     = local.tags
 }

--- a/cookiecutters/terraform-azure/{{ cookiecutter.project_slug }}/tests/test.tftest.hcl
+++ b/cookiecutters/terraform-azure/{{ cookiecutter.project_slug }}/tests/test.tftest.hcl
@@ -10,7 +10,7 @@ variables {
 provider "azurerm" {
   # NOTE: Replace subscription_id with the actual Azure subscription ID
   # where you intend to run tests.
-  subscription_id = "{{ cookiecutter.azure_subscription_id }}"
+  subscription_id = "{{ cookiecutter.tests_azure_subscription_id }}"
   features {}
 }
 

--- a/cookiecutters/terraform-azure/{{ cookiecutter.project_slug }}/trivy.yaml
+++ b/cookiecutters/terraform-azure/{{ cookiecutter.project_slug }}/trivy.yaml
@@ -1,0 +1,12 @@
+misconfiguration:
+  scanners:
+    - terraform
+    - terraformplan-json
+    - terraformplan-snapshot
+
+  terraform:
+    exclude-downloaded-modules: false
+    # NOTE: Optional - set to n-number of var files as needed
+    # vars: ["terraform.tfvars"]
+
+exit-code: 1

--- a/cookiecutters/terraform-azure/{{ cookiecutter.project_slug }}/variables.tf
+++ b/cookiecutters/terraform-azure/{{ cookiecutter.project_slug }}/variables.tf
@@ -12,4 +12,9 @@ variable "tags" {
   type        = map(string)
   description = "A map of tags to assign to the resources."
   default     = {}
-}
+}{% if cookiecutter.is_config_or_module == "config" %}
+
+variable "subscription_id" {
+  type        = string
+  description = "The Azure subscription to which resources will be deployed"
+}{% endif %}

--- a/cookiecutters/terraform-azure/{{ cookiecutter.project_slug }}/{{ "providers.tf" if cookiecutter.is_config_or_module == "config" else "" }}
+++ b/cookiecutters/terraform-azure/{{ cookiecutter.project_slug }}/{{ "providers.tf" if cookiecutter.is_config_or_module == "config" else "" }}
@@ -1,0 +1,4 @@
+provider "azurerm" {
+  subscription_id = var.subscription_id
+  features {}
+}


### PR DESCRIPTION
New Features:

- Prompt for is_config_or_module, this will determine if the generated module is for configuration or is a shared module. Will then generated a providers.tf file if the former.
- Added trivy and tflint configuration to make pre-commit hooks more effective.

Fixes:

- When opting into OpenTofu (the default) pre-commit hooks would behave inconsistently as they default to terraform. Now dynamically update pre-commit hook config to use OpenTofu if OpenTofu is selected.